### PR TITLE
Change Switch partitions layout to remove ext4 storage partition

### DIFF
--- a/packages/libretro/retroarch/package.mk
+++ b/packages/libretro/retroarch/package.mk
@@ -113,20 +113,30 @@ makeinstall_target() {
     cp $PKG_BUILD/libretro-common/audio/dsp_filters/*.dsp $INSTALL/usr/share/audio_filters
   
   # General configuration
-  sed -i -e "s/# libretro_directory =/libretro_directory = \"\/tmp\/cores\"/" $INSTALL/etc/retroarch.cfg
-  sed -i -e "s/# libretro_info_path =/libretro_info_path = \"\/tmp\/cores\"/" $INSTALL/etc/retroarch.cfg
+  if [ "$PROJECT" = "Switch" ]; then
+  	sed -i -e "s/# libretro_directory =/libretro_directory = \"\/usr\/lib\/libretro\"/" $INSTALL/etc/retroarch.cfg
+  	sed -i -e "s/# libretro_info_path =/libretro_info_path = \"\/usr\/lib\/libretro\"/" $INSTALL/etc/retroarch.cfg
+  	sed -i -e "s/# content_database_path =/content_database_path =\/usr\/share\/libretro-database\/rdb/" $INSTALL/etc/retroarch.cfg
+  	sed -i -e "s/# assets_directory =/assets_directory =\/usr\/share\/retroarch-assets/" $INSTALL/etc/retroarch.cfg
+  	sed -i -e "s/# overlay_directory =/overlay_directory =\/usr\/share\/retroarch-overlays/" $INSTALL/etc/retroarch.cfg
+  	sed -i -e "s/# cheat_database_path =/cheat_database_path =\/usr\/share\/libretro-database\/cht/" $INSTALL/etc/retroarch.cfg
+        sed -i -e "s/# video_shader_dir =/video_shader_dir =\/usr\/share\/common-shaders/" $INSTALL/etc/retroarch.cfg
+  else
+  	sed -i -e "s/# libretro_directory =/libretro_directory = \"\/tmp\/cores\"/" $INSTALL/etc/retroarch.cfg
+  	sed -i -e "s/# libretro_info_path =/libretro_info_path = \"\/tmp\/cores\"/" $INSTALL/etc/retroarch.cfg
+  	sed -i -e "s/# content_database_path =/content_database_path =\/tmp\/database\/rdb/" $INSTALL/etc/retroarch.cfg
+  	sed -i -e "s/# assets_directory =/assets_directory =\/tmp\/assets/" $INSTALL/etc/retroarch.cfg
+  	sed -i -e "s/# overlay_directory =/overlay_directory =\/tmp\/overlays/" $INSTALL/etc/retroarch.cfg
+  	sed -i -e "s/# cheat_database_path =/cheat_database_path =\/tmp\/database\/cht/" $INSTALL/etc/retroarch.cfg
+        sed -i -e "s/# video_shader_dir =/video_shader_dir =\/tmp\/shaders/" $INSTALL/etc/retroarch.cfg
+  fi
   sed -i -e "s/# rgui_browser_directory =/rgui_browser_directory =\/storage\/roms/" $INSTALL/etc/retroarch.cfg
-  sed -i -e "s/# content_database_path =/content_database_path =\/tmp\/database\/rdb/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# playlist_directory =/playlist_directory =\/storage\/playlists/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# savefile_directory =/savefile_directory =\/storage\/savefiles/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# savestate_directory =/savestate_directory =\/storage\/savestates/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# system_directory =/system_directory =\/storage\/system/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# screenshot_directory =/screenshot_directory =\/storage\/screenshots/" $INSTALL/etc/retroarch.cfg
-  sed -i -e "s/# video_shader_dir =/video_shader_dir =\/tmp\/shaders/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# rgui_show_start_screen = true/rgui_show_start_screen = false/" $INSTALL/etc/retroarch.cfg
-  sed -i -e "s/# assets_directory =/assets_directory =\/tmp\/assets/" $INSTALL/etc/retroarch.cfg
-  sed -i -e "s/# overlays_directory =/overlays_directory =\/tmp\/overlays/" $INSTALL/etc/retroarch.cfg
-  sed -i -e "s/# cheat_database_path =/cheat_database_path =\/tmp\/database\/cht/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# menu_driver = \"rgui\"/menu_driver = \"xmb\"/" $INSTALL/etc/retroarch.cfg
 
   # Quick menu
@@ -164,7 +174,12 @@ makeinstall_target() {
   sed -i -e "s/# input_driver = sdl/input_driver = udev/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# input_max_users = 16/input_max_users = 5/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# input_autodetect_enable = true/input_autodetect_enable = true/" $INSTALL/etc/retroarch.cfg
-  sed -i -e "s/# joypad_autoconfig_dir =/joypad_autoconfig_dir = \/tmp\/joypads/" $INSTALL/etc/retroarch.cfg
+  if [ "$PROJECT" = "Switch" ]; then
+    sed -i -e "s/# joypad_autoconfig_dir =/joypad_autoconfig_dir = \/etc\/retroarch-joypad-autoconfig/" $INSTALL/etc/retroarch.cfg
+  else
+    sed -i -e "s/# joypad_autoconfig_dir =/joypad_autoconfig_dir = \/tmp\/joypads/" $INSTALL/etc/retroarch.cfg
+  fi
+
   sed -i -e "s/# input_remapping_directory =/input_remapping_directory = \/storage\/remappings/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# input_menu_toggle_gamepad_combo = 0/input_menu_toggle_gamepad_combo = 2/" $INSTALL/etc/retroarch.cfg
   sed -i -e "s/# all_users_control_menu = false/all_users_control_menu = true/" $INSTALL/etc/retroarch.cfg
@@ -229,11 +244,13 @@ post_install() {
   
   enable_service retroarch-autostart.service
   enable_service retroarch.service
-  enable_service tmp-cores.mount
-  enable_service tmp-joypads.mount
-  enable_service tmp-database.mount
-  enable_service tmp-assets.mount
-  enable_service tmp-shaders.mount
+  if [ "$PROJECT" != "Switch" ]; then
+	  enable_service tmp-cores.mount
+	  enable_service tmp-joypads.mount
+	  enable_service tmp-database.mount
+	  enable_service tmp-assets.mount
+	  enable_service tmp-shaders.mount
+  fi
 }
 
 post_makeinstall_target() {

--- a/projects/Switch/packages/busybox/scripts/init
+++ b/projects/Switch/packages/busybox/scripts/init
@@ -659,7 +659,8 @@
 
     wakeonlan
   
-    mount --bind /flash/storage /storage
+    mkdir -p /flash/lakka/storage
+    mount --bind /flash/lakka/storage /storage
   }
 
   # Make last bootloader label (installer, live, run etc.) as the new default

--- a/projects/Switch/packages/busybox/scripts/init
+++ b/projects/Switch/packages/busybox/scripts/init
@@ -27,6 +27,7 @@
   /usr/bin/busybox mkdir -p /tmp
   /usr/bin/busybox mkdir -p /flash
   /usr/bin/busybox mkdir -p /sysroot
+  /usr/bin/busybox mkdir -p /storage
 
   # mount all needed special filesystems
   /usr/bin/busybox mount -t devtmpfs devtmpfs /dev
@@ -658,7 +659,7 @@
 
     wakeonlan
   
-    ln -s /flash/storage/ /storage
+    mount --bind /flash/storage /storage
   }
 
   # Make last bootloader label (installer, live, run etc.) as the new default
@@ -964,14 +965,14 @@
     progress "Preparing system"
 
     if [ "$SYSTEM_TORAM" = "no" -o "$INSTALLED_MEMORY" -lt "$SYSTEM_TORAM_LIMIT" ]; then
-      mount_part "/flash/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
+      mount_part "/flash/lakka/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
     else
       cp /flash/$IMAGE_SYSTEM /dev/$IMAGE_SYSTEM
-      mount_part "/dev/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
+      mount_part "/dev/lakka/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
     fi
 
     mount --move /flash /sysroot/flash
-    ln -s /storage/ /sysroot/storage
+    mount --move /storage /sysroot/storage
 
     if [ ! -d "/sysroot/usr/lib/modules/$(uname -r)/" -a -f "/sysroot/usr/lib/systemd/systemd" ]; then
       echo ""

--- a/projects/Switch/packages/busybox/scripts/init
+++ b/projects/Switch/packages/busybox/scripts/init
@@ -966,10 +966,11 @@
     progress "Preparing system"
 
     if [ "$SYSTEM_TORAM" = "no" -o "$INSTALLED_MEMORY" -lt "$SYSTEM_TORAM_LIMIT" ]; then
-      mount_part "/flash/lakka/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
+      mount_part "/flash/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
     else
+      mkdir -p /dev/lakka #because /dev/$IMAGE_SYSTEM = "/dev/lakka/SYSTEM"
       cp /flash/$IMAGE_SYSTEM /dev/$IMAGE_SYSTEM
-      mount_part "/dev/lakka/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
+      mount_part "/dev/$IMAGE_SYSTEM" "/sysroot" "ro,loop"
     fi
 
     mount --move /flash /sysroot/flash

--- a/projects/Switch/packages/busybox/scripts/init
+++ b/projects/Switch/packages/busybox/scripts/init
@@ -27,7 +27,6 @@
   /usr/bin/busybox mkdir -p /tmp
   /usr/bin/busybox mkdir -p /flash
   /usr/bin/busybox mkdir -p /sysroot
-  /usr/bin/busybox mkdir -p /storage
 
   # mount all needed special filesystems
   /usr/bin/busybox mount -t devtmpfs devtmpfs /dev
@@ -43,10 +42,10 @@
   UPDATE_ROOT=/storage/.update
   UPDATE_DIR="$UPDATE_ROOT"
 
-  UPDATE_KERNEL="KERNEL"
-  UPDATE_SYSTEM="SYSTEM"
-  IMAGE_KERNEL="KERNEL"
-  IMAGE_SYSTEM="SYSTEM"
+  UPDATE_KERNEL="lakka/KERNEL"
+  UPDATE_SYSTEM="lakka/SYSTEM"
+  IMAGE_KERNEL="lakka/KERNEL"
+  IMAGE_SYSTEM="lakka/SYSTEM"
 
   BOOT_STEP="start"
   MD5_FAILED="0"
@@ -435,7 +434,7 @@
 
       # loopback file needs writable /flash all the time
       if [ "${disk%%=*}" != "FILE" ]; then
-        mount -o remount,ro /flash
+        mount -o remount,rw /flash
       fi
       sync
     fi
@@ -564,10 +563,6 @@
       /usr/bin/busybox umount /flash
     fi
 
-    if /usr/bin/busybox mountpoint -q /storage ; then
-      /usr/bin/busybox umount /storage
-    fi
-
     usleep 2000000
     echo "Please turn off your Nintendo Switch now by pressing the POWER button for 10 seconds"
     # /usr/bin/busybox reboot
@@ -655,42 +650,15 @@
 
     wakeonlan
 
-    mount_part "$boot" "/flash" "ro,noatime"
+    mount_part "$boot" "/flash" "rw,noatime"
   }
 
   mount_storage() {
     progress "Mounting storage"
 
-    if [ "$LIVE" = "yes" ]; then
-      # mount tmpfs and exit early. disk=xx is not allowed in live mode
-      mount -t tmpfs none /storage
-      return
-    fi
-
     wakeonlan
-
-    if [ -n "$disk" ]; then
-      if [ -n "$OVERLAY" ]; then
-        OVERLAY_DIR=`cat /sys/class/net/eth0/address | tr -d :`
-
-        mount_part "$disk" "/storage" "rw,noatime"
-        mkdir -p /storage/$OVERLAY_DIR
-        umount /storage
-
-        # split $disk into $target,$options so we can append $OVERLAY_DIR
-        options="${disk#*,}"
-        target="${disk%%,*}"
-        if [ "$options" = "$disk" ]; then
-          disk="$target/$OVERLAY_DIR"
-        else
-          disk="$target/$OVERLAY_DIR,$options"
-        fi
-      fi
-      mount_part "$disk" "/storage" "rw,noatime"
-    else
-      # /storage should always be writable
-      mount -t tmpfs none /storage
-    fi
+  
+    ln -s /flash/storage/ /storage
   }
 
   # Make last bootloader label (installer, live, run etc.) as the new default
@@ -706,7 +674,7 @@
           mount -o remount,rw /flash
           sed -i "s/^DEFAULT .*/DEFAULT $SYSLINUX_DEFAULT/" /flash/syslinux.cfg
           [ -f /flash/EFI/BOOT/syslinux.cfg ] && cp /flash/syslinux.cfg /flash/EFI/BOOT/syslinux.cfg
-          mount -o remount,ro /flash
+          mount -o remount,rw /flash
         fi
       fi
     fi
@@ -1003,7 +971,7 @@
     fi
 
     mount --move /flash /sysroot/flash
-    mount --move /storage /sysroot/storage
+    ln -s /storage/ /sysroot/storage
 
     if [ ! -d "/sysroot/usr/lib/modules/$(uname -r)/" -a -f "/sysroot/usr/lib/systemd/systemd" ]; then
       echo ""
@@ -1043,20 +1011,6 @@
 
   BOOT_STEP=final
 
-  # log if booting from usb / removable storage
-  STORAGE=$(cat /proc/mounts | grep " /sysroot/storage " | awk '{print $1}' | awk -F '/' '{print $3}')
-  FLASH=$(cat /proc/mounts | grep " /sysroot/flash " | awk '{print $1}' | awk -F '/' '{print $3}')
-  for i in $STORAGE $FLASH ; do
-    if [ -n "$i" ] ; then
-      removable="/sys/class/block/*/$i/../removable"
-      if [ -e $removable ] ; then
-        if [ "$(cat $removable 2>/dev/null)" = "1" ] ; then
-          echo "### BIG FAT WARNING" > /dev/kmsg
-          echo "### $i is removable. suspend/resume may not work" > /dev/kmsg
-        fi
-      fi
-    fi
-  done
   # move some special filesystems
   /usr/bin/busybox mount --move /dev /sysroot/dev
   /usr/bin/busybox mount --move /proc /sysroot/proc
@@ -1070,10 +1024,6 @@
   # swap can not be used over nfs.(see scripts/mount-swap)
   if [ "$STORAGE_NETBOOT" = "yes" ] ; then
     echo "" > /sysroot/dev/.storage_netboot
-  fi
-
-  if [ -f /sysroot/storage/.please_resize_me ] ; then
-    INIT_UNIT="--unit=fs-resize.target"
   fi
 
   BACKUP_FILE=`ls -1 /sysroot/storage/.restore/??????????????.tar 2>/dev/null | head -n 1`

--- a/projects/Switch/packages/switch-bootloader/bootscript/boot.txt
+++ b/projects/Switch/packages/switch-bootloader/bootscript/boot.txt
@@ -1,6 +1,6 @@
 mmc dev 1
-load mmc 1:1 0x83000000 KERNEL
+load mmc 1:1 0x83000000 lakka/KERNEL
 load mmc 1:1 0x8d000000 boot/tegra210-nintendo-switch.dtb
-setenv bootargs 'console=tty0 boot=/dev/mmcblk0p1 ro fbcon=rotate:3 rootwait disk=/dev/mmcblk0p2 loglevel=2 quiet ssh consoleblank=0'
+setenv bootargs 'console=tty0 boot=/dev/mmcblk0p1 ro fbcon=rotate:3 rootwait loglevel=2 quiet ssh consoleblank=0'
 usb reset
 booti 0x83000000 - 0x8d000000

--- a/projects/Switch/packages/switch-bootloader/release
+++ b/projects/Switch/packages/switch-bootloader/release
@@ -2,7 +2,7 @@
 
 . config/options $1
 
-mkdir -p $RELEASE_DIR/3rdparty/bootloader/boot
+mkdir -p $RELEASE_DIR/boot
 
-cp -PR $INSTALL/usr/share/bootloader/boot/tegra210-nintendo-switch.dtb $RELEASE_DIR/3rdparty/bootloader/boot
-cp -PR $INSTALL/usr/share/bootloader/boot/boot.scr $RELEASE_DIR/3rdparty/bootloader/boot
+cp -PR $INSTALL/usr/share/bootloader/boot/tegra210-nintendo-switch.dtb $RELEASE_DIR/boot
+cp -PR $INSTALL/usr/share/bootloader/boot/boot.scr $RELEASE_DIR/boot

--- a/projects/Switch/patches/openssh/openssh-ignore-keydir-permissions.patch
+++ b/projects/Switch/patches/openssh/openssh-ignore-keydir-permissions.patch
@@ -1,0 +1,31 @@
+--- a/authfile.c	2016-07-28 00:54:27.000000000 +0200
++++ b/authfile.c	2018-07-03 19:13:08.496275544 +0200
+@@ -169,28 +169,6 @@
+ int
+ sshkey_perm_ok(int fd, const char *filename)
+ {
+-	struct stat st;
+-
+-	if (fstat(fd, &st) < 0)
+-		return SSH_ERR_SYSTEM_ERROR;
+-	/*
+-	 * if a key owned by the user is accessed, then we check the
+-	 * permissions of the file. if the key owned by a different user,
+-	 * then we don't care.
+-	 */
+-#ifdef HAVE_CYGWIN
+-	if (check_ntsec(filename))
+-#endif
+-	if ((st.st_uid == getuid()) && (st.st_mode & 077) != 0) {
+-		error("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
+-		error("@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @");
+-		error("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
+-		error("Permissions 0%3.3o for '%s' are too open.",
+-		    (u_int)st.st_mode & 0777, filename);
+-		error("It is required that your private key files are NOT accessible by others.");
+-		error("This private key will be ignored.");
+-		return SSH_ERR_KEY_BAD_PERMISSIONS;
+-	}
+ 	return 0;
+ }
+ 

--- a/scripts/image
+++ b/scripts/image
@@ -328,26 +328,55 @@ if [ "$1" = "release" -o "$1" = "mkimage" -o "$1" = "amlpkg" -o "$1" = "noobs" ]
      cp -PR $BUILD/imx6-mfgtool2-tbs-matrix-*/* $RELEASE_DIR/MfgTool2-TBS-Matrix
   fi
 
-  cp $ROOT/README* $RELEASE_DIR
-  cp $ROOT/CHANGELOG* $RELEASE_DIR
-  echo "$TARGET_VERSION" > $RELEASE_DIR/RELEASE
+  if [ "$PROJECT" != "Switch" ]; then
+    cp $ROOT/README* $RELEASE_DIR
+    cp $ROOT/CHANGELOG* $RELEASE_DIR
+    echo "$TARGET_VERSION" > $RELEASE_DIR/RELEASE
 
-  if [ -n "$MEDIACENTER" ] ; then
-    echo "Kodi commit: `scripts/git_version $MEDIACENTER`" >> $RELEASE_DIR/RELEASE
+    if [ -n "$MEDIACENTER" ] ; then
+      echo "Kodi commit: `scripts/git_version $MEDIACENTER`" >> $RELEASE_DIR/RELEASE
+    fi
+  else
+    mkdir -p $RELEASE_DIR/lakka
+    cp $ROOT/README* $RELEASE_DIR/lakka
+    cp $ROOT/CHANGELOG* $RELEASE_DIR/lakka
+    echo "$TARGET_VERSION" > $RELEASE_DIR/lakka/RELEASE
   fi
 
-  mkdir -p $RELEASE_DIR/licenses
-  cp $ROOT/licenses/* $RELEASE_DIR/licenses
+  if [ "$PROJECT" = "Switch" ]; then
+    mkdir -p $RELEASE_DIR/lakka/licenses
+    cp $ROOT/licenses/* $RELEASE_DIR/lakka/licenses
+  else
+    mkdir -p $RELEASE_DIR/licenses
+    cp $ROOT/licenses/* $RELEASE_DIR/licenses
+  fi
 
-  mkdir -p $RELEASE_DIR/target
-  cp $TARGET_IMG/$IMAGE_NAME.system $RELEASE_DIR/target/SYSTEM
-  cp $TARGET_IMG/$IMAGE_NAME.kernel $RELEASE_DIR/target/KERNEL
+
+  if [ "$PROJECT" = "Switch" ]; then
+    mkdir -p $RELEASE_DIR/lakka/storage
+    cp $TARGET_IMG/$IMAGE_NAME.system $RELEASE_DIR/lakka/SYSTEM
+    cp $TARGET_IMG/$IMAGE_NAME.kernel $RELEASE_DIR/lakka/KERNEL
+  else
+    mkdir -p $RELEASE_DIR/target
+    cp $TARGET_IMG/$IMAGE_NAME.system $RELEASE_DIR/target/SYSTEM
+    cp $TARGET_IMG/$IMAGE_NAME.kernel $RELEASE_DIR/target/KERNEL
+  fi
+
 
   # create md5sum's
-  ( cd $RELEASE_DIR;
-    md5sum -t target/SYSTEM > target/SYSTEM.md5;
-    md5sum -t target/KERNEL > target/KERNEL.md5;
-  )
+  if [ "$PROJECT" = "Switch" ]; then
+          ( cd $RELEASE_DIR;
+            md5sum -t lakka/SYSTEM > lakka/SYSTEM.md5;
+            md5sum -t lakka/KERNEL > lakka/KERNEL.md5;
+          )
+  else
+          ( cd $RELEASE_DIR;
+            md5sum -t target/SYSTEM > target/SYSTEM.md5;
+            md5sum -t target/KERNEL > target/KERNEL.md5;
+          )
+  fi
+  
+  
 
   # create target directory
   mkdir -p $TARGET_IMG
@@ -359,7 +388,7 @@ if [ "$1" = "release" -o "$1" = "mkimage" -o "$1" = "amlpkg" -o "$1" = "noobs" ]
   tar cf $TARGET_IMG/$IMAGE_NAME.tar -C target $IMAGE_NAME
 
   # create image files if requested
-  if [[ ( "$1" = "amlpkg" || "$1" = "noobs" || "$1" = "mkimage" ) && -n "$BOOTLOADER" ]]; then
+  if [[ ( "$1" = "amlpkg" || "$1" = "noobs" || "$1" = "mkimage" ) && -n "$BOOTLOADER" && "$PROJECT" != "Switch" ]]; then
     # projects can set KERNEL_NAME (kernel.img)
     if [ -z "$KERNEL_NAME" ] ; then
       KERNEL_NAME="KERNEL"


### PR DESCRIPTION
`/storage` is now a bind mount to `/flash/lakka/storage`. This allows Lakka to coexist with the Switch OS (and soon the Switch OS emunand) without much troubles, simplified installation and update process and simplified storage file transfers. This doesn't affect other projects.