### PR TITLE
Fix compiler missing errors when building linux (host)

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -103,7 +103,7 @@ PKG_AUTORECONF="no"
 
 if [ "$TARGET_KERNEL_ARCH" = "arm64" -a "$TARGET_ARCH" = "arm" ]; then
   if [ "$PROJECT" = "Switch" ]; then
-	  PKG_DEPENDS_HOST="$PKG_DEPENDS_HOST gcc-linaro-aarch64-linux-gnu:host"
+    PKG_DEPENDS_HOST="$PKG_DEPENDS_HOST gcc-linaro-aarch64-linux-gnu:host"
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET gcc-linaro-aarch64-linux-gnu:host"
     export PATH=$TOOLCHAIN/lib/gcc-linaro-aarch64-linux-gnu/bin/:$PATH
     TARGET_PREFIX=aarch64-linux-gnu-
@@ -222,11 +222,11 @@ pre_make_target() {
     FW_LIST="$(find $PKG_BUILD/external-firmware \( -type f -o -type l \) \( -iname '*.bin' -o -iname '*.fw' -o -path '*/intel-ucode/*' \) | sed 's|.*external-firmware/||' | sort | xargs)"
     sed -i "s|CONFIG_EXTRA_FIRMWARE=.*|CONFIG_EXTRA_FIRMWARE=\"${FW_LIST}\"|" $PKG_BUILD/.config
   fi
-  
+
   if [ "$PROJECT" = "Switch" ]; then
     mkdir -p $PKG_BUILD/external-firmware
     cp -a $(get_build_dir kernel-firmware)/{nvidia,brcm} $PKG_BUILD/external-firmware
-    
+
     FW_LIST="$(find $PKG_BUILD/external-firmware \( -type f -o -type l \) \( -iname '*.bin' -o -iname '*.txt' -o -iname '*.hcd' \) | sed 's|.*external-firmware/||' | sort | xargs)"
     sed -i "s|CONFIG_EXTRA_FIRMWARE=.*|CONFIG_EXTRA_FIRMWARE=\"${FW_LIST}\"|" $PKG_BUILD/.config
   fi

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -103,6 +103,7 @@ PKG_AUTORECONF="no"
 
 if [ "$TARGET_KERNEL_ARCH" = "arm64" -a "$TARGET_ARCH" = "arm" ]; then
   if [ "$PROJECT" = "Switch" ]; then
+	  PKG_DEPENDS_HOST="$PKG_DEPENDS_HOST gcc-linaro-aarch64-linux-gnu:host"
     PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET gcc-linaro-aarch64-linux-gnu:host"
     export PATH=$TOOLCHAIN/lib/gcc-linaro-aarch64-linux-gnu/bin/:$PATH
     TARGET_PREFIX=aarch64-linux-gnu-


### PR DESCRIPTION
Tried to find out the origin of this error when compiling the Linux kernel
```
In file included from ./include/linux/page-flags.h:10:0,
                 from kernel/bounds.c:10:
./include/linux/bug.h:5:10: fatal error: asm/bug.h: No such file or directory
 #include <asm/bug.h>
          ^~~~~~~~~~~
compilation terminated.
  HOSTCC  scripts/dtc/livetree.o
make[2]: *** [Kbuild:21: kernel/bounds.s] Error 1
make[1]: *** [Makefile:1112: prepare0] Error 2
make[1]: *** Waiting for unfinished jobs....
  CC      scripts/mod/devicetable-offsets.s
  HOSTCC  scripts/dtc/treesource.o
In file included from ./include/linux/string.h:6:0,
                 from ./include/linux/uuid.h:20,
                 from ./include/linux/mod_devicetable.h:13,
                 from scripts/mod/devicetable-offsets.c:3:
./include/linux/compiler.h:245:10: fatal error: asm/barrier.h: No such file or directory
 #include <asm/barrier.h>
          ^~~~~~~~~~~~~~~
compilation terminated.
```

Checked the whole Linux building process and noticed that when building the host part there were some unattended error messages:

```
          BUILD    linux (host)
Executing (host): make ARCH=arm headers_check
make[1]: Entering directory '/root/build.Lakka-Switch.arm-2.2-devel/linux-eb837f0'
./scripts/gcc-version.sh: line 26: aarch64-linux-gnu-gcc: command not found
./scripts/gcc-version.sh: line 27: aarch64-linux-gnu-gcc: command not found
make[1]: aarch64-linux-gnu-gcc: Command not found
```

I patched the PKG_DEPENDS_HOST so that build script gets the compiler before running through the host part of the Linux building process.