### PR TITLE
Fix compiler dependencies when building coreboot

### DIFF
--- a/projects/Switch/packages/switch-coreboot/package.mk
+++ b/projects/Switch/packages/switch-coreboot/package.mk
@@ -21,6 +21,7 @@
 PKG_NAME="switch-coreboot"
 PKG_VERSION="1becafe"
 PKG_ARCH="any"
+PKG_DEPENDS_HOST="gcc-linaro-aarch64-linux-gnu:host gcc-linaro-arm-linux-gnueabi:host"
 PKG_DEPENDS_TARGET="toolchain switch-coreboot:host switch-u-boot gcc-linaro-aarch64-linux-gnu:host gcc-linaro-arm-linux-gnueabi:host"
 PKG_SITE="https://github.com/lakka-switch/coreboot"
 PKG_GIT_URL="$PKG_SITE"
@@ -28,6 +29,8 @@ PKG_GIT_URL="$PKG_SITE"
 PKG_AUTORECONF="no"
 
 make_host() {
+  export PATH=$TOOLCHAIN/lib/gcc-linaro-aarch64-linux-gnu/bin/:$PATH
+  export PATH=$TOOLCHAIN/lib/gcc-linaro-arm-linux-gnueabi/bin/:$PATH
   make nintendo_switch_defconfig
   make iasl
   make tools


### PR DESCRIPTION
Building switch-coreboot crashes when building the host part when the linaro compiler is missing. Since the build process already installs the compiler, I added it to the dependencies in the script.