### PR TITLE
Fix packages that need to be told where the libraries and includes are

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -119,7 +119,9 @@ else
 fi
 
 if [ "$PROJECT" = "Switch" ]; then
-    PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET kernel-firmware"
+    PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET kernel-firmware openssl:host"
+    export C_INCLUDE_PATH="$TOOLCHAIN/include:$C_INCLUDE_PATH"
+    export LIBRARY_PATH="$TOOLCHAIN/lib:$LIBRARY_PATH"
 fi
 
 if [ "$TARGET_ARCH" = "x86_64" ]; then

--- a/projects/Switch/packages/switch-coreboot/package.mk
+++ b/projects/Switch/packages/switch-coreboot/package.mk
@@ -21,8 +21,8 @@
 PKG_NAME="switch-coreboot"
 PKG_VERSION="1becafe"
 PKG_ARCH="any"
-PKG_DEPENDS_HOST="gcc-linaro-aarch64-linux-gnu:host gcc-linaro-arm-linux-gnueabi:host"
-PKG_DEPENDS_TARGET="toolchain switch-coreboot:host switch-u-boot gcc-linaro-aarch64-linux-gnu:host gcc-linaro-arm-linux-gnueabi:host"
+PKG_DEPENDS_HOST="gcc-linaro-aarch64-linux-gnu:host gcc-linaro-arm-linux-gnueabi:host zlib:host openssl:host"
+PKG_DEPENDS_TARGET="toolchain switch-coreboot:host switch-u-boot gcc-linaro-aarch64-linux-gnu:host gcc-linaro-arm-linux-gnueabi:host curl:host"
 PKG_SITE="https://github.com/lakka-switch/coreboot"
 PKG_GIT_URL="$PKG_SITE"
 
@@ -31,6 +31,8 @@ PKG_AUTORECONF="no"
 make_host() {
   export PATH=$TOOLCHAIN/lib/gcc-linaro-aarch64-linux-gnu/bin/:$PATH
   export PATH=$TOOLCHAIN/lib/gcc-linaro-arm-linux-gnueabi/bin/:$PATH
+  export C_INCLUDE_PATH="$TOOLCHAIN/include:$C_INCLUDE_PATH"
+  export LIBRARY_PATH="$TOOLCHAIN/lib:$LIBRARY_PATH"
   make nintendo_switch_defconfig
   make iasl
   make tools


### PR DESCRIPTION
Linux kernel and switch coreboot build process won't find the include and lib paths from the toolchain unless they are told explicitly

This happens when trying to compile using the provided Dockerfile

```
docker build -t lakka .
docker run --rm \
    -v $(pwd):/root \
    -e DISTRO="Lakka" \
    -e PROJECT="Switch" \
    -e ARCH="arm" \
    -ti lakka:latest
``` 

#### linux (target)

The first crash ocurs when building linux
```
  BUILD    linux (target)
make[1]: Entering directory '/root/build.Lakka-Switch.arm-2.2-devel/linux-eb837f0'
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
  LEX     scripts/kconfig/zconf.lex.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
scripts/kconfig/conf  --oldconfig Kconfig
#
# configuration written to .config
#

...

  HOSTLD  scripts/dtc/dtc
make[1]: *** [Makefile:1076: scripts] Error 2
make[1]: Leaving directory '/root/build.Lakka-Switch.arm-2.2-devel/linux-eb837f0'
Makefile:27: recipe for target 'image' failed
make: *** [image] Error 2
```
This is fixed by setting openssl:host as a dependency and setting the environment variables so that GCC can find the paths

#### switch-coreboot (host)

After that the next error appears on switch-coreboot

```
  BUILD    switch-coreboot (host)
make[1]: Entering directory '/root/build.Lakka-Switch.arm-2.2-devel/switch-coreboot-1becafe'
#
# configuration written to /root/build.Lakka-Switch.arm-2.2-devel/switch-coreboot-1becafe/.config
#
make[1]: Leaving directory '/root/build.Lakka-Switch.arm-2.2-devel/switch-coreboot-1becafe'
make[1]: Entering directory '/root/build.Lakka-Switch.arm-2.2-devel/switch-coreboot-1becafe'
Welcome to the coreboot cross toolchain builder v1.50 (October 15th, 2017)

Building toolchain using 1 thread(s).

ERROR: Missing tool: Please install 'zlib (zlib1g-dev or zlib-devel)'. (eg sudo apt-get install zlib (zlib1g-dev or zlib-devel))
make[2]: *** [Makefile:36: build_iasl] Error 1
make[1]: *** [util/crossgcc/Makefile.inc:52: iasl] Error 2
make[1]: Leaving directory '/root/build.Lakka-Switch.arm-2.2-devel/switch-coreboot-1becafe'
Makefile:27: recipe for target 'image' failed
make: *** [image] Error 2
```

this one is fixed by setting  zlib:host as a dependency, but it will still not get detected unless you set the environment variables so that GCC can find the paths

#### switch-coreboot (target)

Target just needs curl:host, so it was added to the dependencies.