### PR TITLE
switch-u-boot depends on swig

### DIFF
--- a/projects/Switch/packages/switch-u-boot/package.mk
+++ b/projects/Switch/packages/switch-u-boot/package.mk
@@ -21,7 +21,7 @@
 PKG_NAME="switch-u-boot"
 PKG_VERSION="0ee0219"
 PKG_ARCH="any"
-PKG_DEPENDS_TARGET="toolchain gcc-linaro-aarch64-linux-gnu:host gcc-linaro-arm-linux-gnueabi:host Python Python:host"
+PKG_DEPENDS_TARGET="toolchain gcc-linaro-aarch64-linux-gnu:host gcc-linaro-arm-linux-gnueabi:host Python Python:host swig:host"
 PKG_SITE="https://github.com/lakka-switch/u-boot"
 PKG_GIT_URL="$PKG_SITE"
 


### PR DESCRIPTION
switch-u-boot depends on the swig binary to build

This happens when trying to compile using the provided Dockerfile

```
docker build -t lakka .
docker run --rm \
    -v $(pwd):/root \
    -e DISTRO="Lakka" \
    -e PROJECT="Switch" \
    -e ARCH="arm" \
    -ti lakka:latest
```
It depends on #15 being fixed (because it's built afterwards)

#### switch-u-boot (target)

The error triggers when building switch-u-boot (target)

```
  BUILD    switch-u-boot (target)
make[1]: Entering directory '/root/build.Lakka-Switch.arm-2.2-devel/switch-u-boot-0ee0219'
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  SHIPPED scripts/kconfig/zconf.tab.c
  SHIPPED scripts/kconfig/zconf.lex.c
  SHIPPED scripts/kconfig/zconf.hash.c
  HOSTCC  scripts/kconfig/zconf.tab.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
make[1]: Leaving directory '/root/build.Lakka-Switch.arm-2.2-devel/switch-u-boot-0ee0219'
make[1]: Entering directory '/root/build.Lakka-Switch.arm-2.2-devel/switch-u-boot-0ee0219'
scripts/kconfig/conf  --silentoldconfig Kconfig
  CHK     include/config.h
  UPD     include/config.h
  CFG     u-boot.cfg
  GEN     include/autoconf.mk.dep
  GEN     include/autoconf.mk
  CHK     include/config/uboot.release
  CHK     include/generated/timestamp_autogenerated.h
  UPD     include/generated/timestamp_autogenerated.h
  HOSTCC  scripts/dtc/dtc.o
  SHIPPED scripts/dtc/pylibfdt/libfdt.i
  PYMOD   scripts/dtc/pylibfdt/_libfdt.so
  UPD     include/config/uboot.release
  HOSTCC  scripts/dtc/flattree.o
unable to execute 'swig': No such file or directory
error: command 'swig' failed with exit status 1
make[4]: *** [scripts/dtc/pylibfdt/Makefile:26: scripts/dtc/pylibfdt/_libfdt.so] Error 1
make[3]: *** [scripts/Makefile.build:425: scripts/dtc/pylibfdt] Error 2
make[3]: *** Waiting for unfinished jobs....
  CHK     include/generated/version_autogenerated.h
  UPD     include/generated/version_autogenerated.h
  CC      lib/asm-offsets.s
  CC      arch/arm/lib/asm-offsets.s
  CHK     include/generated/generic-asm-offsets.h
  CHK     include/generated/asm-offsets.h
  UPD     include/generated/generic-asm-offsets.h
  CHK     include/config.h
  UPD     include/generated/asm-offsets.h
  CFG     u-boot.cfg
  LDS     u-boot.lds
make[2]: *** [scripts/Makefile.build:425: scripts/dtc] Error 2
make[1]: *** [Makefile:491: scripts] Error 2
make[1]: Leaving directory '/root/build.Lakka-Switch.arm-2.2-devel/switch-u-boot-0ee0219'
Makefile:27: recipe for target 'image' failed
make: *** [image] Error 2
```

is fixed by setting swig:host as a dependency