### PR TITLE
pcsx and mupen64plus

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -253,7 +253,7 @@
 
   LAKKA_MIRROR="http://sources.lakka.tv"
 
-  LIBRETRO_CORES="2048 4do 81 atari800 beetle-bsnes beetle-lynx beetle-ngp beetle-pce beetle-pcfx beetle-psx beetle-saturn beetle-supergrafx beetle-vb beetle-wswan bluemsx bsnes bsnes-mercury cannonball cap32 chailove citra crocods desmume desmume-2015 dinothawr dolphin dosbox dosbox-svn easyrpg fbalpha fceumm freeintv fuse-libretro gambatte genesis-plus-gx gearboy gme gpsp gw-libretro handy hatari higan-sfc higan-sfc-balanced ishiiruka kronos lutro mame2003-plus melonds meowpc98 mesen mgba mrboom mupen64plus-next nestopia nxengine o2em openlara pcsx_rearmed picodrive pocketcdg ppsspp prboom prosystem puae px68k reicast reminiscence sameboy scummvm snes9x snes9x2002 snes9x2005 snes9x2005_plus snes9x2010 stella tgbdual theodore tyrquake uae4arm uzem vbam vecx vice virtualjaguar xrick yabasanshiro yabause"
+  LIBRETRO_CORES="2048 4do 81 atari800 beetle-bsnes beetle-lynx beetle-ngp beetle-pce beetle-pcfx beetle-psx beetle-saturn beetle-supergrafx beetle-vb beetle-wswan bluemsx bsnes bsnes-mercury cannonball cap32 chailove citra crocods desmume desmume-2015 dinothawr dolphin dosbox dosbox-svn easyrpg fbalpha fceumm freeintv fuse-libretro gambatte genesis-plus-gx gearboy gme gpsp gw-libretro handy hatari higan-sfc higan-sfc-balanced ishiiruka kronos lutro mame2003-plus melonds meowpc98 mesen mgba mrboom mupen64plus-next mupen64plus-next-oldgliden nestopia nxengine o2em openlara pcsx_rearmed picodrive pocketcdg ppsspp prboom prosystem puae px68k reicast reminiscence sameboy scummvm snes9x snes9x2002 snes9x2005 snes9x2005_plus snes9x2010 stella tgbdual theodore tyrquake uae4arm uzem vbam vecx vice virtualjaguar xrick yabasanshiro yabause"
 
   RA_PLAYLIST_NAMES=""\
 "Atari - 2600.lpl;"\

--- a/packages/libretro/core-info/patches/core-info-01-mupen-oldgliden-info.patch
+++ b/packages/libretro/core-info/patches/core-info-01-mupen-oldgliden-info.patch
@@ -1,0 +1,19 @@
+diff --git a/dist/info/mupen64plus_next_oldgliden_libretro.info b/dist/info/mupen64plus_next_oldgliden_libretro.info
+new file mode 100644
+index 00000000..9b0fa81a
+--- /dev/null
++++ b/dist/info/mupen64plus_next_oldgliden_libretro.info
+@@ -0,0 +1,13 @@
++display_name = "Nintendo - Nintendo 64 (Mupen64Plus-Next Old GLideN64)"
++authors = "m4xw|Hacktarux|Mupen64Plus Team"
++supported_extensions = "n64|v64|z64|bin|u1|ndd"
++corename = "Mupen64Plus-Next (Old GLideN64)"
++manufacturer = "Nintendo"
++categories = "Emulator"
++systemname = "Nintendo 64"
++systemid = "nintendo_64"
++database = "Nintendo - Nintendo 64|Nintendo - Nintendo 64DD"
++license = "GPLv2"
++permissions = "dynarec_optional"
++display_version = "1.0"
++supports_no_game = "false"

--- a/packages/libretro/mupen64plus-next-oldgliden/package.mk
+++ b/packages/libretro/mupen64plus-next-oldgliden/package.mk
@@ -1,0 +1,83 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+PKG_NAME="mupen64plus-next"
+PKG_VERSION="73ca3a8"
+PKG_GIT_BRANCH="mupen_next"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPLv2"
+PKG_SITE="https://github.com/libretro/mupen64plus-libretro-nx"
+PKG_GIT_URL="$PKG_SITE"
+PKG_DEPENDS_TARGET="toolchain nasm:host"
+PKG_PRIORITY="optional"
+PKG_SECTION="libretro"
+PKG_SHORTDESC="Improved mupen64plus libretro core reimplementation"
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+pre_configure_target() {
+  strip_lto
+}
+
+make_target() {
+  case $PROJECT in
+    RPi|Gamegirl|Slice)
+      CFLAGS="$CFLAGS -I$SYSROOT_PREFIX/usr/include/interface/vcos/pthreads \
+	              -I$SYSROOT_PREFIX/usr/include/interface/vmcs_host/linux"
+      make platform=rpi GLES=1 FORCE_GLES=1 WITH_DYNAREC=arm
+      ;;
+    RPi2|Slice3)
+      CFLAGS="$CFLAGS -I$SYSROOT_PREFIX/usr/include/interface/vcos/pthreads \
+                      -I$SYSROOT_PREFIX/usr/include/interface/vmcs_host/linux"
+      make platform=rpi2 GLES=1 FORCE_GLES=1 HAVE_NEON=1 WITH_DYNAREC=arm
+      ;;
+    imx6)
+      CFLAGS="$CFLAGS -DLINUX -DEGL_API_FB"
+      CPPFLAGS="$CPPFLAGS -DLINUX -DEGL_API_FB"
+      make platform=unix GLES=1 FORCE_GLES=1 HAVE_NEON=1 WITH_DYNAREC=arm
+      ;;
+    Generic)
+      make
+      ;;
+    OdroidC1)
+      make platform=odroid BOARD=ODROID-C1 GLES=1 FORCE_GLES=1 HAVE_NEON=1 WITH_DYNAREC=arm
+      ;;
+    OdroidXU3)
+      make platform=odroid BOARD=ODROID-XU3 GLES=1 FORCE_GLES=1 HAVE_NEON=1 WITH_DYNAREC=arm
+      ;;
+    ROCK960)
+      make platform=unix-gles GLES=1 FORCE_GLES=1 HAVE_NEON=1 WITH_DYNAREC=arm
+      ;;
+    *)
+      if [ "$OPENGLES_SUPPORT" = "yes" ]; then
+        make platform=unix-gles GLES=1 FORCE_GLES=1 HAVE_NEON=1 WITH_DYNAREC=$ARCH
+      else
+        make platform=unix WITH_DYNAREC=$ARCH
+      fi
+      ;;
+  esac
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/usr/lib/libretro
+  cp mupen64plus_next_libretro.so $INSTALL/usr/lib/libretro/mupen64plus_next_oldgliden_libretro.so
+}

--- a/packages/libretro/pcsx_rearmed/package.mk
+++ b/packages/libretro/pcsx_rearmed/package.mk
@@ -19,13 +19,11 @@
 ################################################################################
 
 PKG_NAME="pcsx_rearmed"
-PKG_VERSION="80209d1"
+PKG_VERSION="3796032"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPLv2"
-PKG_SITE="https://github.com/libretro/pcsx_rearmed"
-PKG_SITE_ALT="https://github.com/libretro/pcsx_rearmed_switch"
-PKG_VERSION_ALT="b716d51"
+PKG_SITE="https://github.com/libretro/pcsx_rearmed_switch"
 PKG_GIT_URL="$PKG_SITE"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_PRIORITY="optional"
@@ -38,14 +36,6 @@ PKG_AUTORECONF="no"
 
 configure_target() {
   strip_gold
-}
-
-pre_patch() {
-  cd $PKG_BUILD
-  git remote add switch $PKG_SITE_ALT  # add m4xw
-  git fetch switch master         # pull from m4xw
-  git checkout $PKG_VERSION_ALT   # latest known good from m4xw
-  git rebase -q $PKG_VERSION      # rebase onto known good from mainline
 }
 
 make_target() {


### PR DESCRIPTION
- pcsx
    - jump back to m4xw's fork, he rebased with mainline
    - tested to be sure CHD support is still working
    - you can delete the pcsx_rearmed_switch repo in the lakka-switch org if you want.
- mupen64plus
    - mupen-next has a regression with Yoshi's Island 64 (and maybe others)
    - this config was suggested by m4xw and tested to work with YI64