### PR TITLE
adding fbneo, yeeting fbalpha, dolphin improvements

### DIFF
--- a/distributions/Lakka/options
+++ b/distributions/Lakka/options
@@ -253,7 +253,7 @@
 
   LAKKA_MIRROR="http://sources.lakka.tv"
 
-  LIBRETRO_CORES="2048 4do 81 atari800 beetle-bsnes beetle-lynx beetle-ngp beetle-pce beetle-pcfx beetle-psx beetle-saturn beetle-supergrafx beetle-vb beetle-wswan bluemsx bsnes bsnes-mercury cannonball cap32 chailove citra crocods desmume desmume-2015 dinothawr dolphin dosbox dosbox-svn easyrpg fbalpha fceumm freeintv fuse-libretro gambatte genesis-plus-gx gearboy gme gpsp gw-libretro handy hatari higan-sfc higan-sfc-balanced ishiiruka kronos lutro mame2003-plus mame2010 melonds meowpc98 mesen mgba mrboom mupen64plus-next nestopia nxengine o2em openlara pcsx_rearmed picodrive pocketcdg ppsspp prboom prosystem puae px68k reicast reminiscence sameboy scummvm snes9x snes9x2002 snes9x2005 snes9x2005_plus snes9x2010 stella tgbdual theodore tyrquake uae4arm uzem vbam vecx vice virtualjaguar xrick yabasanshiro yabause"
+  LIBRETRO_CORES="2048 4do 81 atari800 beetle-bsnes beetle-lynx beetle-ngp beetle-pce beetle-pcfx beetle-psx beetle-saturn beetle-supergrafx beetle-vb beetle-wswan bluemsx bsnes bsnes-mercury cannonball cap32 chailove citra crocods desmume desmume-2015 dinothawr dolphin dosbox dosbox-svn easyrpg fbneo fceumm freeintv fuse-libretro gambatte genesis-plus-gx gearboy gme gpsp gw-libretro handy hatari higan-sfc higan-sfc-balanced ishiiruka kronos lutro mame2003-plus mame2010 melonds meowpc98 mesen mgba mrboom mupen64plus-next nestopia nxengine o2em openlara pcsx_rearmed picodrive pocketcdg ppsspp prboom prosystem puae px68k reicast reminiscence sameboy scummvm snes9x snes9x2002 snes9x2005 snes9x2005_plus snes9x2010 stella tgbdual theodore tyrquake uae4arm uzem vbam vecx vice virtualjaguar xrick yabasanshiro yabause"
 
   RA_PLAYLIST_NAMES=""\
 "Atari - 2600.lpl;"\
@@ -276,7 +276,7 @@
 "Dinothawr.lpl;"\
 "DOOM.lpl;"\
 "DOS.lpl;"\
-"FB Alpha - Arcade Games.lpl;"\
+"FBNeo - Arcade Games"\
 "Flashback.lpl;"\
 "GCE - Vectrex.lpl;"\
 "Lutro.lpl;"\
@@ -343,7 +343,7 @@
 "/tmp/cores/dinothawr_libretro.so;"\
 "/tmp/cores/prboom_libretro.so;"\
 "/tmp/cores/dosbox_libretro.so;"\
-"/tmp/cores/fbalpha_libretro.so;"\
+"/tmp/cores/fbneo_libretro.so;"\
 "/tmp/cores/reminiscence_libretro.so;"\
 "/tmp/cores/vecx_libretro.so;"\
 "/tmp/cores/lutro_libretro.so;"\

--- a/packages/libretro/core-info/package.mk
+++ b/packages/libretro/core-info/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="core-info"
-PKG_VERSION="9b3e8ea"
+PKG_VERSION="18674bd"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/libretro/dolphin/package.mk
+++ b/packages/libretro/dolphin/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="dolphin"
-PKG_VERSION="68f9fa7"
+PKG_VERSION="e8f27d0"
 PKG_REV="1"
 PKG_ARCH="x86_64 aarch64"
 PKG_LICENSE="GPLv2"

--- a/packages/libretro/fbneo/package.mk
+++ b/packages/libretro/fbneo/package.mk
@@ -18,35 +18,27 @@
 #  http://www.gnu.org/copyleft/gpl.html
 ################################################################################
 
-PKG_NAME="fbalpha"
-PKG_VERSION="5081611"
+PKG_NAME="fbneo"
+PKG_VERSION="06f6f81"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="Non-commercial"
-PKG_SITE="https://github.com/libretro/fbalpha"
+PKG_SITE="https://github.com/libretro/fbneo"
 PKG_GIT_URL="$PKG_SITE"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_PRIORITY="optional"
 PKG_SECTION="libretro"
-PKG_SHORTDESC="Port of Final Burn Alpha to Libretro (v0.2.97.38)."
-PKG_LONGDESC="Currently, FB Alpha supports games on Capcom CPS-1 and CPS-2 hardware, SNK Neo-Geo hardware, Toaplan hardware, Cave hardware, and various games on miscellaneous hardware. "
+PKG_SHORTDESC="Port of Final Burn Neo to Libretro"
+PKG_LONGDESC="Currently, FB Neo supports games on Capcom CPS-1 and CPS-2 hardware, SNK Neo-Geo hardware, Toaplan hardware, Cave hardware, and various games on miscellaneous hardware. "
 
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
 make_target() {
-  if [ "$ARCH" == "arm" ]; then
-    if [[ "$TARGET_FPU" =~ "neon" ]]; then
-      make -f makefile.libretro CC=$CC CXX=$CXX HAVE_NEON=1 profile=performance
-    else
-      make -f makefile.libretro CC=$CC CXX=$CXX profile=performance
-    fi
-  else
-    make -f makefile.libretro CC=$CC CXX=$CXX profile=accuracy
-  fi
+  make -C src/burner/libretro CC=$CC CXX=$CXX profile=accuracy
 }
 
 makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/libretro
-  cp fbalpha_libretro.so $INSTALL/usr/lib/libretro/
+  cp src/burner/libretro/fbneo_libretro.so $INSTALL/usr/lib/libretro/
 }

--- a/packages/libretro/libretro-database/package.mk
+++ b/packages/libretro/libretro-database/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="libretro-database"
-PKG_VERSION="d491e37"
+PKG_VERSION="122c69b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
fbneo: new core, replaces fbalpha
 - compiles fine
 - tested with donpachi, metal slug x, metal slug 5

dolphin: adding texture cache accuracy core option
 - compiles fine
 - tested with pokemon XD, which had graphical glitches when texture cache accuracy was set to fast. 'safe' fixes those issues.